### PR TITLE
autodetect tile shape

### DIFF
--- a/src/minerva_scripts/blend/mem.py
+++ b/src/minerva_scripts/blend/mem.py
@@ -24,11 +24,10 @@ def f32_to_bgr(f_img, color=[1, 1, 1]):
     return (256*f_bgr).astype(np.uint8)
 
 
-def tile(all_img, t_shape, colors, ranges=None):
+def tile(all_img, colors, ranges=None):
     """blend all channels given
     Arguments:
         all_img: list of numpy image channels for a tile
-        t_shape: uint16 height, width tile shape
         colors: N-channel by b, g, r float32 color
         ranges: N-channel by min, max float32 range
 
@@ -36,11 +35,13 @@ def tile(all_img, t_shape, colors, ranges=None):
         uint8 y by x by 3 color BGR image
     """
     n_chan = len(list(zip(colors, all_img)))
+    t_shape = np.amax([a.shape for a in all_img], 0)
+    t_shape_color = tuple(t_shape) + (3,)
+    # Default range to 0,1 for all channels
     if ranges is None:
         ranges = np.float32(([0, 1],)*n_chan)
 
     # final buffer for blending
-    t_shape_color = tuple(t_shape) + (3,)
     img_buffer = np.zeros(t_shape_color, dtype=np.float32)
 
     # Process as many channesl as have colors and ranges

--- a/src/minerva_scripts/scripts/combine.py
+++ b/src/minerva_scripts/scripts/combine.py
@@ -126,8 +126,7 @@ def main(args=sys.argv[1:]):
             continue
 
         # from memory, blend all channels loaded
-        img_buffer = mem.tile(all_buffer, tile_shape,
-                              all_colors, all_ranges)
+        img_buffer = mem.tile(all_buffer, all_colors, all_ranges)
 
         # Write the image buffer to a file
         out_file = out_path_format.format(k_time, k_detail, z, y, x)

--- a/src/minerva_scripts/scripts/debug/visual.py
+++ b/src/minerva_scripts/scripts/debug/visual.py
@@ -75,11 +75,10 @@ def generic_test_tile(t_chans, t_id, t_keys, t_ok, t_list=None):
         t_ok: assumed output channel
         t_list: list of tests to run
     """
-    shape = t_keys.get('shape')
     colors = t_keys.get('colors')
     ranges = t_keys.get('ranges')
     # Blend all input tiles
-    t_out = mem.tile(t_chans, shape, colors, ranges)
+    t_out = mem.tile(t_chans, colors, ranges)
     t_pair = t_ok, t_out
 
     # Run standard tests by default

--- a/tests/blend/test_mem.py
+++ b/tests/blend/test_mem.py
@@ -53,11 +53,10 @@ def generic_test_tile(t_chans, t_ok, t_keys, t_list=None):
         t_ok: assumed output image
         t_list: list of tests to run
     """
-    shape = t_keys.get('shape')
     colors = t_keys.get('colors')
     ranges = t_keys.get('ranges')
     # Blend all input tiles
-    t_out = tile(t_chans, shape, colors, ranges)
+    t_out = tile(t_chans, colors, ranges)
     t_pair = t_ok, t_out
 
     # Run standard tests by default
@@ -83,7 +82,6 @@ def easy_test_tile(t_r, t_c, t_in, t_ok, t_list=None):
     t_keys = {
         'ranges': t_r[np.newaxis],
         'colors': t_c[np.newaxis],
-        'shape': t_in.shape
     }
     generic_test_tile([t_in], t_ok, t_keys, t_list)
 
@@ -101,7 +99,6 @@ def many_test_tile(ranges, colors, t_chans, t_ok, t_list=None):
     t_keys = {
         'ranges': ranges,
         'colors': colors,
-        'shape': t_chans[0].shape
     }
     generic_test_tile(t_chans, t_ok, t_keys,  t_list)
 


### PR DESCRIPTION
No longer need to pass shape to `blend.mem.tile`